### PR TITLE
added missing "libsemanage-python" package for Oracle Linux

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Install SELinux libsemanage-python support
+  package:
+    name: "{{ item }}"
+  with_items:
+    - libsemanage-python
 
 - name: Install Apache.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- name: Install SELinux libsemanage-python support
+
+- name: Install SELinux libsemanage-python support.
   package:
     name: "{{ item }}"
   with_items:
@@ -23,14 +24,14 @@
     name: httpd_can_network_connect_db
     state: yes
     persistent: yes
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Set SELinux permissions to allow Apache to email password resets.
   seboolean:
     name: httpd_can_sendmail
     state: yes
     persistent: yes
-  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
+  when: ansible_selinux is defined and ansible_selinux and ansible_selinux.status == 'enabled'
 
 - name: Add PostgreSQL repo.
   package:
@@ -45,7 +46,6 @@
 - name: Install pgAdmin4-web.
   yum:
     name: pgadmin4-web
-    enablerepo: ol7_developer_EPEL
     state: present
 
 - name: Install client packages.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 
 - name: Install SELinux libsemanage-python support.
-  package:
-    name: "{{ item }}"
-  with_items:
-    - libsemanage-python
+  yum:
+    name:
+      - libsemanage-python
+    state: present
 
 - name: Install Apache.
   yum:
@@ -19,31 +19,25 @@
     enabled: yes
     state: started
 
-- name: Set SELinux permissions to allow Apache to access pgadmin sqlite db.
-  seboolean:
-    name: httpd_can_network_connect_db
-    state: yes
-    persistent: yes
-  when:
-    - ansible_selinux is defined
-    - ansible_selinux
-    - ansible_selinux.status == 'enabled'
+- block:
+  - name: Set SELinux permissions to allow Apache to access pgadmin sqlite db.
+    seboolean:
+      name: httpd_can_network_connect_db
+      state: yes
+      persistent: yes
 
-- name: Set SELinux permissions to allow Apache to use LDAP authentication.
-  seboolean:
-    name: httpd_can_network_connect
-    state: yes
-    persistent: yes
-  when:
-    - ansible_selinux is defined
-    - ansible_selinux
-    - ansible_selinux.status == 'enabled'
+  - name: Set SELinux permissions to allow Apache to use LDAP authentication.
+    seboolean:
+      name: httpd_can_network_connect
+      state: yes
+      persistent: yes
 
-- name: Set SELinux permissions to allow Apache to email password resets.
-  seboolean:
-    name: httpd_can_sendmail
-    state: yes
-    persistent: yes
+  - name: Set SELinux permissions to allow Apache to email password resets.
+    seboolean:
+      name: httpd_can_sendmail
+      state: yes
+      persistent: yes
+
   when:
     - ansible_selinux is defined
     - ansible_selinux
@@ -106,7 +100,8 @@
     recurse: yes
   register: shell_setup_path
 
-- debug:
+- name: Show location of setup-web.sh.
+  debug:
     var: shell_setup_path
 
 - name: Locate the setup python script.
@@ -117,7 +112,8 @@
     recurse: yes
   register: python_setup_path
 
-- debug:
+- name: Show location of pgadmin4-web directory.
+  debug:
     var: python_setup_path
 
 - name: Initialize pgAdmin4.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,12 +23,14 @@
     name: httpd_can_network_connect_db
     state: yes
     persistent: yes
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Set SELinux permissions to allow Apache to email password resets.
   seboolean:
     name: httpd_can_sendmail
     state: yes
     persistent: yes
+  when: ansible_selinux is defined and ansible_selinux != False and ansible_selinux.status == 'enabled'
 
 - name: Add PostgreSQL repo.
   package:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,7 @@
 - name: Install pgAdmin4-web.
   yum:
     name: pgadmin4-web
+    enablerepo: ol7_developer_EPEL
     state: present
 
 - name: Install client packages.


### PR DESCRIPTION
SELinux related tasks cannot be executed under "Oracle Linux" when package
"libsemanage-python" is not installed.